### PR TITLE
Encode POST body

### DIFF
--- a/ovos_tts_plugin_mimic3_server/__init__.py
+++ b/ovos_tts_plugin_mimic3_server/__init__.py
@@ -119,7 +119,7 @@ class Mimic3ServerTTSPlugin(TTS):
             # Try all public urls until one works
             audio_data = self._get_from_public_servers(voice, sentence)
         else:
-            r = requests.post(self.url, params={"voice": voice}, data=sentence)
+            r = requests.post(self.url, params={"voice": voice}, data=sentence.encode())
             if not r.ok:
                 raise RemoteTTSException(f"Mimic3 server error: {r.reason}")
             else:


### PR DESCRIPTION
When sending strings in UTF-8, the mimic 3 server is unable to decode them, showing this error:

```
docker-mimic3-1  | ERROR:mimic3_http.app:'utf-8' codec can't decode byte 0xfa in position 1: invalid start byte
docker-mimic3-1  | Traceback (most recent call last):
docker-mimic3-1  |   File "/home/mimic3/app/.venv/lib/python3.9/site-packages/quart/app.py", line 1673, in full_dispatch_request
docker-mimic3-1  |     result = await self.dispatch_request(request_context)
docker-mimic3-1  |   File "/home/mimic3/app/.venv/lib/python3.9/site-packages/quart/app.py", line 1718, in dispatch_request
docker-mimic3-1  |     return await self.ensure_async(handler)(**request_.view_args)
docker-mimic3-1  |   File "/home/mimic3/app/mimic3_http/app.py", line 202, in app_tts
docker-mimic3-1  |     text = (await request.data).decode()
docker-mimic3-1  | UnicodeDecodeError: 'utf-8' codec can't decode byte 0xfa in position 1: invalid start byte
```

Using `sentence.encode()` avoids this error