### PR TITLE
Resolve bugs and add tests for bad TTS returns

### DIFF
--- a/ovos_tts_plugin_mimic3_server/__init__.py
+++ b/ovos_tts_plugin_mimic3_server/__init__.py
@@ -21,8 +21,8 @@ class Mimic3ServerTTSPlugin(TTS):
     """Interface to Mimic3 Server TTS."""
     public_servers = [
         "http://mycroft.blue-systems.com:59125/api/tts",
-        "https://mimic3.ziggyai.online",
-        "https://tts.smartgic.io/mimic3"
+        "https://mimic3.ziggyai.online/api/tts",
+        "https://tts.smartgic.io/mimic3/api/tts"
     ]
     default_voices = {
         # TODO add default voice for every lang
@@ -119,9 +119,11 @@ class Mimic3ServerTTSPlugin(TTS):
             # Try all public urls until one works
             audio_data = self._get_from_public_servers(voice, sentence)
         else:
-            r = requests.post(self.url, params={"voice": voice}, data=sentence.encode())
+            r = requests.post(self.url, params={"voice": voice},
+                              data=sentence.encode())
             if not r.ok:
-                raise RemoteTTSException(f"Mimic3 server error: {r.reason}")
+                raise RemoteTTSException(f"Mimic3 server ({self.url}) error: "
+                                         f"{r.status_code} - {r.reason}")
             else:
                 audio_data = r.content
 

--- a/test/unittests/test_synth.py
+++ b/test/unittests/test_synth.py
@@ -1,11 +1,31 @@
 import unittest
 
+from ovos_plugin_manager.templates.tts import RemoteTTSException
+
 from ovos_tts_plugin_mimic3_server import Mimic3ServerTTSPlugin
 
 mimic = Mimic3ServerTTSPlugin()
 
 
 class TestTTS(unittest.TestCase):
+    def test_public_servers(self):
+        passing_servers = 0
+        for server in mimic.public_servers:
+            path = f"/tmp/{server.split('/')[2].replace('.', '_')}.wav"
+            mimic.url = server
+            try:
+                audio, phonemes = mimic.get_tts("hello", path, lang="en-gb")
+                self.assertEqual(audio, path)
+                with open(audio, 'rb') as f:
+                    audio_content = f.read()
+                    self.assertIn(b'WAVE', audio_content)
+                passing_servers += 1
+            except RemoteTTSException as e:
+                print(f"{server} failing unit tests")
+                print(e)
+        self.assertGreaterEqual(passing_servers, 1,
+                                "No Public Servers Passing Tests!")
+
     def test_default_voice(self):
         path = "/tmp/hello_ap.wav"
         # also testing that en-gb resolves to the internally used (wrong) en-uk


### PR DESCRIPTION
Fix typos in default server URLs
Add unit test to ensure at least one public server is live
@AIIX The blue-systems endpoint is returning 500; can you check server logs there to see what's happening?