### PR TITLE
Fix Ziggai and Smart'Gic TTS URL

### DIFF
--- a/ovos_tts_plugin_mimic3_server/__init__.py
+++ b/ovos_tts_plugin_mimic3_server/__init__.py
@@ -21,8 +21,8 @@ class Mimic3ServerTTSPlugin(TTS):
     """Interface to Mimic3 Server TTS."""
     public_servers = [
         "http://mycroft.blue-systems.com:59125/api/tts",
-        "https://mimic3.ziggyai.online/api/tts",
-        "https://tts.smartgic.io/mimic3/api/tts"
+        "https://mimic3.ziggyai.online",
+        "https://tts.smartgic.io/mimic3"
     ]
     default_voices = {
         # TODO add default voice for every lang


### PR DESCRIPTION
Because they both now using the `ovos_tts_server` to expose Mimic3.