### PR TITLE
fix url for ziggyai

### DIFF
--- a/ovos_tts_plugin_mimic3_server/__init__.py
+++ b/ovos_tts_plugin_mimic3_server/__init__.py
@@ -21,8 +21,7 @@ class Mimic3ServerTTSPlugin(TTS):
     """Interface to Mimic3 Server TTS."""
     public_servers = [
         "http://mycroft.blue-systems.com:59125/api/tts",
-        "https://mimic3sample.ziggyai.online/api/tts",
-        "https://tts.smartgic.io/mimic3/api/tts"
+        "https://mimic3sample.ziggyai.online/api/tts"
     ]
     default_voices = {
         # TODO add default voice for every lang

--- a/ovos_tts_plugin_mimic3_server/__init__.py
+++ b/ovos_tts_plugin_mimic3_server/__init__.py
@@ -21,7 +21,7 @@ class Mimic3ServerTTSPlugin(TTS):
     """Interface to Mimic3 Server TTS."""
     public_servers = [
         "http://mycroft.blue-systems.com:59125/api/tts",
-        "https://mimic3.ziggyai.online/api/tts",
+        "https://mimic3sample.ziggyai.online/api/tts",
         "https://tts.smartgic.io/mimic3/api/tts"
     ]
     default_voices = {


### PR DESCRIPTION
My ziggyai server has changed.  The new address that works with this server is `https://mimic3sample.ziggyai.online/api/tts`

The other has been changed to use `ovos-tts-plugin-server`